### PR TITLE
Avoid eager loading FastH3 validation videos

### DIFF
--- a/layouts/shortcodes/fasth3-validation-gallery.html
+++ b/layouts/shortcodes/fasth3-validation-gallery.html
@@ -8,7 +8,8 @@
 <div class="fasth3-validation-grid">
   {{- range $gallery.samples }}
   <article class="fasth3-validation-card">
-    <video controls playsinline preload="metadata"
+    <video controls playsinline preload="none"
+      style="aspect-ratio: {{ .width }} / {{ .height }};"
       aria-label="FastH3 validation sample {{ .sample_id }} with audio">
       <source src="{{ .video }}" type="video/mp4">
       Your browser does not support MP4 video with audio.
@@ -44,6 +45,7 @@
   display: block;
   width: 100%;
   max-height: 32rem;
+  object-fit: contain;
   background: #000;
   border-radius: 8px;
 }


### PR DESCRIPTION
## Summary

- change the 15-video FastH3 validation gallery from `preload="metadata"` to `preload="none"`
- preserve each video's aspect ratio from the manifest to avoid layout shifts before playback
- use `object-fit: contain` for mixed landscape, square, and portrait samples

## Why

The gallery currently renders 15 MP4 elements with `preload="metadata"`. The MP4 metadata is stored near the end of these files, so a cold page load triggers multiple range requests per video and begins downloading roughly 138 MiB of media before the visitor plays anything.

In a cold-cache browser trace, the existing page issued 48 MP4 requests across the hero and gallery. With this change, the gallery issued zero requests before interaction; only the hero video retained its existing metadata preload behavior (3 range requests).

## Verification

- `git diff --check`
- browser cold-cache network trace against equivalent rendered markup: gallery requests reduced from 45 to 0
- verified all 15 gallery videos render with `preload="none"` and stable manifest-derived aspect ratios

A full Hugo build was not run locally because Hugo is not installed and the local Docker daemon is unavailable.